### PR TITLE
fix compile issues after Xcode update

### DIFF
--- a/Formula/gdal2.rb
+++ b/Formula/gdal2.rb
@@ -47,6 +47,7 @@ class Gdal2 < Formula
   depends_on "libgeotiff"
   depends_on "proj"
   depends_on "geos"
+  depends_on "json-c"
 
   depends_on "sqlite" # To ensure compatibility with SpatiaLite.
   depends_on "pcre" # for REGEXP operator in SQLite/Spatialite driver


### PR DESCRIPTION
gdal2 build failed because it couldn't find json.h

 - added json-c build dependency 